### PR TITLE
New GridInfo class to hold info parsed from grd file

### DIFF
--- a/steno3d_surfer/parser.py
+++ b/steno3d_surfer/parser.py
@@ -22,6 +22,11 @@ class GridInfo(properties.HasProperties):
     zmax = properties.Float('maximum data value', required=False)
     data = properties.Array('grid of data values', shape=('*', '*'))
 
+    @properties.validator
+    def _validate_datasize(self):
+        if self.data.shape != (self.ncol, self.nrow):
+            raise ValueError('Data shape must be ncol x nrow')
+
     def to_steno3d(self, project=None, as_topo=True):
         """Create a project from GridInfo
 

--- a/tests/test_surfer.py
+++ b/tests/test_surfer.py
@@ -61,15 +61,15 @@ class TestSurfer(unittest.TestCase):
         ascii_file = path.sep.join(self.assets + ['ascii.grd'])
         parser = steno3d.parsers.grd(ascii_file)
         grd_dict = parser.extract()
-        assert grd_dict['ncol'] == 5
-        assert grd_dict['nrow'] == 7
-        assert grd_dict['xll'] == 0
-        assert grd_dict['yll'] == 200
-        assert grd_dict['xsize'] == 25
-        assert abs(grd_dict['ysize'] - 100./6) < .01
-        assert grd_dict['zmin'] == 1.5
-        assert grd_dict['zmax'] == 2.5
-        assert np.array_equiv(grd_dict['data'],
+        assert grd_dict.ncol == 5
+        assert grd_dict.nrow == 7
+        assert grd_dict.xll == 0
+        assert grd_dict.yll == 200
+        assert grd_dict.xsize == 25
+        assert abs(grd_dict.ysize - 100./6) < .01
+        assert grd_dict.zmin == 1.5
+        assert grd_dict.zmax == 2.5
+        assert np.array_equiv(grd_dict.data,
                               np.array([[1.5, 1.6, 1.7, 1.8, 1.9],
                                         [1.6, 1.7, 1.8, 1.9, 2.0],
                                         [1.7, 1.8, 1.9, 2.0, 2.1],


### PR DESCRIPTION
- Parse functions return GridInfo objects
    - These can be created directly with `extract`
    - These are type-checked, validated objects, so they may be modified after extraction
    - They have a `to_steno3d` method to create a project/surface
- Old `parse` function now uses `extract` and `to_steno3d`